### PR TITLE
feat: Improve Axe and Weapon Immersion

### DIFF
--- a/RaftVRMod/RaftVRMod/ItemComponents/AxeVR.cs
+++ b/RaftVRMod/RaftVRMod/ItemComponents/AxeVR.cs
@@ -45,7 +45,7 @@ namespace RaftVR.ItemComponents
             }
         }
 
-        private void OnCollisionStay(Collision collision)
+        private void OnCollisionEnter(Collision collision)
         {
             if (cooldownTimer > 0 || PlayerItemManager.IsBusy) return;
 

--- a/RaftVRMod/RaftVRMod/ItemComponents/MeleeWeaponVR.cs
+++ b/RaftVRMod/RaftVRMod/ItemComponents/MeleeWeaponVR.cs
@@ -55,7 +55,7 @@ namespace RaftVR.ItemComponents
             }
         }
 
-        private void OnCollisionStay(Collision collision)
+        private void OnCollisionEnter(Collision collision)
         {
             if (cooldownTimer > 0 || playerNetwork.PlayerScript.IsDead) return;
             if (weapon.attackMask == (weapon.attackMask | ( 1 << collision.collider.gameObject.layer)))


### PR DESCRIPTION
Adjusted the collision checking to require the user to swing their axe for tree chopping and stab/swing their weapon when attacking.

ie. you can no longer place your Axe in a tree and hold it there for multiple chops, or place Spear in the shark and hold it there for multiple attacks, you must pull the Axe/Weapon out and re-hit for a second action.