### PR TITLE
feat: Improve Axe and Weapon Immersion

### DIFF
--- a/RaftVRMod/RaftVRMod/ItemComponents/AxeVR.cs
+++ b/RaftVRMod/RaftVRMod/ItemComponents/AxeVR.cs
@@ -10,6 +10,7 @@ namespace RaftVR.ItemComponents
         private Network_Player playerNetwork;
         private float cooldown;
         private float cooldownTimer;
+        private bool disableHit;
         private CanvasHelper canvas;
 
         private void Start()
@@ -24,6 +25,8 @@ namespace RaftVR.ItemComponents
             Item_Base item = playerNetwork.PlayerItemManager.useItemController.GetCurrentItemInHand();
 
             cooldown = item.settings_usable.UseButtonCooldown;
+
+            disableHit = false;
 
             canvas = ComponentManager<CanvasHelper>.Value;
 
@@ -45,9 +48,15 @@ namespace RaftVR.ItemComponents
             }
         }
 
+        private void OnCollisionEnter(Collision collision)
+        {
+            // when we enter an object we allow hitting to occur
+            disableHit = false;
+        }
+
         private void OnCollisionStay(Collision collision)
         {
-            if (cooldownTimer > 0 || PlayerItemManager.IsBusy) return;
+            if (cooldownTimer > 0 || disableHit || PlayerItemManager.IsBusy) return;
 
             if (collision.gameObject.tag == "Tree")
             {
@@ -62,6 +71,10 @@ namespace RaftVR.ItemComponents
             if (tree == null || tree.Depleted) return;
 
             cooldownTimer = cooldown;
+
+            // once we've hit we disable hitting again until we get another enter
+            // (user has to act for multiple hits)
+            disableHit = true;
 
             Message_AxeHit message_AxeHit = new Message_AxeHit(Messages.AxeHit, this.playerNetwork, this.playerNetwork.steamID);
             message_AxeHit.treeObjectIndex = (int)tree.PickupNetwork.ObjectIndex;


### PR DESCRIPTION
Adjusted the collision checking to require the user to swing their axe for tree chopping and stab/swing their weapon when attacking.

ie. you can no longer place your Axe in a tree and hold it there for multiple chops, or place Spear in the shark and hold it there for multiple attacks, you must pull the Axe/Weapon out and re-hit for a second action.

Adjustments from #2, instead of just using OnCollisionEnter for the hit logic instead of OnCollisionStay, we leave the main hit logic in OnCollisionStay but also:

1. Set a boolean `disableHit` to true whenever a hit occurs.
2. Check `disableHit` during OnCollisionStay which disables multiple hits.
3. Clear `disableHit` when we get a new OnCollisionEnter to allow another hit to occur.
    1. Note, hit only actually happens once cooldown also ends, which causes the hit sound effect to trigger thus causing the sound and cooldown timer to encourage a user into an optimal chopping / attaching rate 👍 .